### PR TITLE
🔨修复了话廊首页点击图片时意外的导航问题

### DIFF
--- a/src/components/ImageViewer/ImageBox.vue
+++ b/src/components/ImageViewer/ImageBox.vue
@@ -45,7 +45,7 @@ const picStyle = reactive({
 </script>
 
 <template>
-  <n-element :style="containerStyle" @click="open()">
+  <n-element :style="containerStyle" @click.stop="open()">
     <!-- @vue-ignore-error -->
     <img :src="props.src" :style="picStyle" :lazy="props.lazy" onerror="this.style.display = 'none'"/>
   </n-element>

--- a/src/components/ImageViewer/ImageBox.vue
+++ b/src/components/ImageViewer/ImageBox.vue
@@ -45,7 +45,10 @@ const picStyle = reactive({
 </script>
 
 <template>
-  <n-element :style="containerStyle" @click="open()">
+  <n-element :style="containerStyle" @click.stop="(e: MouseEvent) => {
+      e.preventDefault()
+      open()
+    }">
     <!-- @vue-ignore-error -->
     <img :src="props.src" :style="picStyle" :lazy="props.lazy" onerror="this.style.display = 'none'"/>
   </n-element>

--- a/src/components/ImageViewer/ImageBox.vue
+++ b/src/components/ImageViewer/ImageBox.vue
@@ -45,7 +45,7 @@ const picStyle = reactive({
 </script>
 
 <template>
-  <n-element :style="containerStyle" @click.stop="open()">
+  <n-element :style="containerStyle" @click="open()">
     <!-- @vue-ignore-error -->
     <img :src="props.src" :style="picStyle" :lazy="props.lazy" onerror="this.style.display = 'none'"/>
   </n-element>

--- a/src/components/Posters.vue
+++ b/src/components/Posters.vue
@@ -12,7 +12,6 @@ import { FormatTime, OpenLink } from '@/utils/tools';
 import { ErrorOutlined } from '@vicons/material'
 import Avatar from '@/components/Avatar.vue';
 import ImageViewer from '@/components/ImageViewer/ImageViewer.vue';
-import { useRouter } from "vue-router"
 
 export interface PostersStatus {
   mode: 'recommend' | 'search' | 'follow' | 'hot';
@@ -84,15 +83,11 @@ watch(props, () => {
   posters.refresh_time++;
   LoadPosters();
 })
-
-const router = useRouter()
-const open = (i: Poster) => {
-  router.push(`/gallery/${i.id}`)
-}
 </script>
 
 <template>
-    <n-card v-for="i in posters.list" hoverable style="margin-bottom:11px;" @click="open(i)">
+  <router-link v-for="i in posters.list"  :to="'/gallery/' + i['id']" style="text-decoration: none;">
+    <n-card hoverable style="margin-bottom:11px;">
       <div>
         <n-ellipsis :line-clamp="2" :tooltip="false" style="color:var(--text-color-1);font-size:18px;font-weight:bold;margin:0;">{{ i.title }}</n-ellipsis>
       </div>
@@ -131,6 +126,7 @@ const open = (i: Poster) => {
         </span>
       </div>
     </n-card>
+  </router-link>
 
   <div ref="load_more_observer"></div>
 

--- a/src/components/Posters.vue
+++ b/src/components/Posters.vue
@@ -113,8 +113,13 @@ watch(props, () => {
       <ImageViewer v-if="i.images.length" :images="i.images" />
 
       <div style="color:var(--text-color-3);font-size:14px;margin-top: 11px;display:flex;align-items:center;">
-        <div @click="OpenLink('/user/' + i.user.id)" @click.stop=""
-          style="display:flex;align-items: center;flex:1;">
+        <div
+          @click="(e: MouseEvent) => {
+            e.preventDefault()
+            OpenLink('/user/' + i.user.id)
+          }"
+          style="display:flex;align-items: center;flex:1;"
+        >
           <Avatar :user="i.user" :size="24" round />
 
           <div style="width:2em;flex:1;">

--- a/src/components/Posters.vue
+++ b/src/components/Posters.vue
@@ -12,6 +12,7 @@ import { FormatTime, OpenLink } from '@/utils/tools';
 import { ErrorOutlined } from '@vicons/material'
 import Avatar from '@/components/Avatar.vue';
 import ImageViewer from '@/components/ImageViewer/ImageViewer.vue';
+import { useRouter } from "vue-router"
 
 export interface PostersStatus {
   mode: 'recommend' | 'search' | 'follow' | 'hot';
@@ -83,11 +84,15 @@ watch(props, () => {
   posters.refresh_time++;
   LoadPosters();
 })
+
+const router = useRouter()
+const open = (i: Poster) => {
+  router.push(`/gallery/${i.id}`)
+}
 </script>
 
 <template>
-  <router-link v-for="i in posters.list"  :to="'/gallery/' + i['id']" style="text-decoration: none;">
-    <n-card hoverable style="margin-bottom:11px;">
+    <n-card v-for="i in posters.list" hoverable style="margin-bottom:11px;" @click="open(i)">
       <div>
         <n-ellipsis :line-clamp="2" :tooltip="false" style="color:var(--text-color-1);font-size:18px;font-weight:bold;margin:0;">{{ i.title }}</n-ellipsis>
       </div>
@@ -126,7 +131,6 @@ watch(props, () => {
         </span>
       </div>
     </n-card>
-  </router-link>
 
   <div ref="load_more_observer"></div>
 

--- a/src/utils/naive-ui-light-theme-overrides.json
+++ b/src/utils/naive-ui-light-theme-overrides.json
@@ -14,7 +14,7 @@
     "infoColorPressed": "#0087A8FF",
     "warningColor": "#F0A020FF",
     "textColor2": "#245D6BFF",
-    "textColor1": "#00ABD6FF",
+    "textColor1": "#027B99FF",
     "textColor3": "#809ba8FF",
     "fontSize": "16px"
   },


### PR DESCRIPTION
- 修复了话廊首页点击图片时意外的导航问题，现在在话廊首页点击图片时可以正常预览图片，而不会被意外导航到Poster详情内。

- 修复了浅色主题下的文字颜色对比度不足导致的可读性问题
https://github.com/BIT101-dev/BIT101/pull/34#issuecomment-1963700983
![图片](https://github.com/BIT101-dev/BIT101/assets/56217843/2d11701a-4621-4775-99e8-a9adfbd0b1ed)
