### PR TITLE
🚅优化vicons引入方式提升sourceMap调试性能

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,8 +11,23 @@ import LightThemeOverrides from '@/utils/naive-ui-light-theme-overrides.json';
 import DarkThemeOverrides from '@/utils/naive-ui-dark-theme-overrides.json';
 import { useRouter, useRoute } from 'vue-router';
 import { h, ref, onMounted, computed } from 'vue';
-import { MenuRound, HomeOutlined, FingerprintOutlined, PersonOutlined, SchoolOutlined, ArticleOutlined, RefreshOutlined, BookOutlined, ArrowBackOutlined, CalendarMonthOutlined, MailOutlined, MapOutlined, ForumOutlined, BrightnessAutoOutlined, LightModeOutlined, DarkModeOutlined } from '@vicons/material';
-import { QuestionCircleOutlined } from "@vicons/antd"
+import MenuRound from '@vicons/material/MenuRound'
+import HomeOutlined from '@vicons/material/HomeOutlined'
+import FingerprintOutlined from '@vicons/material/FingerprintOutlined'
+import PersonOutlined from '@vicons/material/PersonOutlined'
+import SchoolOutlined from '@vicons/material/SchoolOutlined'
+import ArticleOutlined from '@vicons/material/ArticleOutlined'
+import RefreshOutlined from '@vicons/material/RefreshOutlined'
+import BookOutlined from '@vicons/material/BookOutlined'
+import ArrowBackOutlined from '@vicons/material/ArrowBackOutlined'
+import CalendarMonthOutlined from '@vicons/material/CalendarMonthOutlined'
+import MailOutlined from '@vicons/material/MailOutlined'
+import MapOutlined from '@vicons/material/MapOutlined'
+import ForumOutlined from '@vicons/material/ForumOutlined'
+import BrightnessAutoOutlined from '@vicons/material/BrightnessAutoOutlined'
+import LightModeOutlined from '@vicons/material/LightModeOutlined'
+import DarkModeOutlined from '@vicons/material/DarkModeOutlined'
+import QuestionCircleOutlined from "@vicons/antd/QuestionCircleOutlined"
 import GlobalComponents from './components/GlobalComponents.vue';
 import { hitokoto, WatchNetwork } from './utils/tools';
 import http from './utils/request';

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -6,7 +6,7 @@
 -->
 <script setup lang="ts">
 import store from '@/utils/store';
-import { VerifiedFilled } from '@vicons/material';
+import VerifiedFilled from '@vicons/material/VerifiedFilled';
 import { User } from '@/utils/types';
 import { PropType } from 'vue';
 

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -8,10 +8,15 @@
 <script setup lang="ts">
 import http from '@/utils/request';
 import { h, onMounted, reactive, ref } from 'vue';
-import { MessageOutlined } from '@vicons/material';
+import MessageOutlined from '@vicons/material/MessageOutlined'
+import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import DeleteOutlined from '@vicons/material/DeleteOutlined'
+import ReplyOutlined from '@vicons/material/ReplyOutlined'
+import FeedbackOutlined from '@vicons/material/FeedbackOutlined'
+import MoreVertOutlined from '@vicons/material/MoreVertOutlined'
 import store from '@/utils/store';
 import { FormatTime } from '@/utils/tools';
-import { ThumbUpOutlined, ThumbUpFilled, DeleteOutlined, ReplyOutlined, FeedbackOutlined, MoreVertOutlined } from '@vicons/material';
 import { onBeforeRouteLeave, useRouter } from 'vue-router';
 import { Comment, User } from '@/utils/types';
 import RenderLink from './RenderLink.vue';

--- a/src/components/ImageViewer/ImageModal.vue
+++ b/src/components/ImageViewer/ImageModal.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { defineProps, reactive, defineEmits, ref, watch } from 'vue';
 import { onBeforeRouteLeave } from 'vue-router'
-import { ArrowForwardFilled, ArrowBackFilled, BrokenImageFilled, CloseFilled, SaveFilled, DownloadFilled } from '@vicons/material'
+import ArrowForwardFilled from '@vicons/material/ArrowForwardFilled'
+import ArrowBackFilled from '@vicons/material/ArrowBackFilled'
+import BrokenImageFilled from '@vicons/material/BrokenImageFilled'
+import CloseFilled from '@vicons/material/CloseFilled'
+import DownloadFilled from '@vicons/material/DownloadFilled'
 import { useThemeVars } from 'naive-ui'
 import './ImageModal.css'
 

--- a/src/components/Posters.vue
+++ b/src/components/Posters.vue
@@ -9,7 +9,7 @@ import http from '@/utils/request';
 import { PropType, onMounted, reactive, ref, watch } from 'vue';
 import { Poster } from '@/utils/types';
 import { FormatTime, OpenLink } from '@/utils/tools';
-import { ErrorOutlined } from '@vicons/material'
+import ErrorOutlined from '@vicons/material/ErrorOutlined'
 import Avatar from '@/components/Avatar.vue';
 import ImageViewer from '@/components/ImageViewer/ImageViewer.vue';
 

--- a/src/views/CourseShow.vue
+++ b/src/views/CourseShow.vue
@@ -3,7 +3,9 @@ import http from '@/utils/request';
 import { OpenLink, Share, setTitle } from '@/utils/tools';
 import { computed, onMounted, reactive } from 'vue';
 import { useRoute } from 'vue-router';
-import { ThumbUpOutlined, ThumbUpFilled, ShareOutlined } from '@vicons/material';
+import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import ShareOutlined from '@vicons/material/ShareOutlined'
 import Comment from '@/components/Comment.vue';
 import router from '@/router';
 

--- a/src/views/CourseUpload.vue
+++ b/src/views/CourseUpload.vue
@@ -9,7 +9,7 @@
 import { reactive, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { UploadCustomRequestOptions, UploadInst } from 'naive-ui'
-import { UploadRound } from '@vicons/material'
+import UploadRound from '@vicons/material/UploadRound'
 import http from '@/utils/request'
 import { OpenLink, setTitle } from '@/utils/tools'
 import axios from 'axios'

--- a/src/views/Gallery.vue
+++ b/src/views/Gallery.vue
@@ -8,7 +8,8 @@
 import http from '@/utils/request';
 import { onMounted, reactive, ref, watch } from 'vue';
 import { OpenLink, opacityColor } from '@/utils/tools';
-import { RefreshRound, AddRound } from '@vicons/material'
+import RefreshRound from '@vicons/material/RefreshRound'
+import AddRound from '@vicons/material/AddRound'
 import Posters, { PostersStatus } from '@/components/Posters.vue';
 import { useThemeVars } from 'naive-ui';
 

--- a/src/views/GalleryShow.vue
+++ b/src/views/GalleryShow.vue
@@ -9,7 +9,14 @@ import http from '@/utils/request';
 import { onActivated, onDeactivated, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { FormatTime, setTitle, OpenLink, Share, opacityColor } from '@/utils/tools';
-import { MessageOutlined, EditOutlined, ThumbUpOutlined, ThumbUpFilled, ShareOutlined, ErrorOutlined, DeleteOutlined, FeedbackOutlined } from '@vicons/material';
+import MessageOutlined from '@vicons/material/MessageOutlined'
+import EditOutlined from '@vicons/material/EditOutlined'
+import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import ShareOutlined from '@vicons/material/ShareOutlined'
+import ErrorOutlined from '@vicons/material/ErrorOutlined'
+import DeleteOutlined from '@vicons/material/DeleteOutlined'
+import FeedbackOutlined from '@vicons/material/FeedbackOutlined'
 import Comment from '@/components/Comment.vue';
 import { Poster } from '@/utils/types';
 import Avatar from '@/components/Avatar.vue';

--- a/src/views/Message.vue
+++ b/src/views/Message.vue
@@ -9,7 +9,10 @@ import router from '@/router';
 import http from '@/utils/request';
 import { FormatTime } from '@/utils/tools';
 import { User } from '@/utils/types';
-import { ThumbUpFilled, TextsmsFilled, PersonAddFilled, NotificationsFilled } from '@vicons/material';
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import TextsmsFilled from '@vicons/material/TextsmsFilled'
+import PersonAddFilled from '@vicons/material/PersonAddFilled'
+import NotificationsFilled from '@vicons/material/NotificationsFilled'
 import { NA } from 'naive-ui';
 import { PropType, defineComponent, h, onActivated, onDeactivated, reactive, ref } from 'vue';
 

--- a/src/views/PaperShow.vue
+++ b/src/views/PaperShow.vue
@@ -11,7 +11,10 @@ import { onMounted, reactive } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import PaperRender from '@/components/PaperRender.vue';
 import { FormatTime, setTitle, Share } from '@/utils/tools';
-import { EditOutlined, ThumbUpOutlined, ThumbUpFilled, ShareOutlined } from '@vicons/material';
+import EditOutlined from '@vicons/material/EditOutlined'
+import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import ShareOutlined from '@vicons/material/ShareOutlined'
 import Comment from '@/components/Comment.vue';
 import Avatar from '@/components/Avatar.vue';
 import { User } from '@/utils/types';

--- a/src/views/Report.vue
+++ b/src/views/Report.vue
@@ -11,7 +11,7 @@ import { onMounted, reactive, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { setTitle } from '@/utils/tools';
 import { Claim, Image, Poster } from '@/utils/types';
-import { AddRound } from '@vicons/material';
+import AddRound from '@vicons/material/AddRound';
 import { UploadFileInfo } from 'naive-ui';
 
 const route = useRoute();


### PR DESCRIPTION
https://github.com/07akioni/xicons/issues/356

`@vicons`这个包貌似对 bundler 的 tree-shaking 不太友好, 直接使用`import { ... } from "@vicons/xxx`会把全部的图标一股脑打进 debug 包 (大概8000个吧), 然后 devtools 就在那拉所有文件的 sourceMap, 再然后就是把浏览器卡死了...

![图片](https://github.com/BIT101-dev/BIT101/assets/56217843/450d7c1e-cb07-4baa-a769-e703ebad3e20)
![图片](https://github.com/BIT101-dev/BIT101/assets/56217843/f21d3d39-0798-4897-84da-9240519a0de3)
