### PR TITLE
♻️ 重构评论提交 (#48)

### DIFF
--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -86,6 +86,7 @@ onMounted(() => {
 
 onBeforeRouteLeave((to, from) => {
   sub_comment_list.modal = false;
+  sub_comment.modal = false;
 })
 </script>
 

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -7,40 +7,17 @@
 -->
 <script setup lang="ts">
 import http from '@/utils/request';
-import { h, onMounted, reactive, ref, watch } from 'vue';
-import MessageOutlined from '@vicons/material/MessageOutlined'
-import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
-import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
-import DeleteOutlined from '@vicons/material/DeleteOutlined'
-import ReplyOutlined from '@vicons/material/ReplyOutlined'
-import FeedbackOutlined from '@vicons/material/FeedbackOutlined'
-import MoreVertOutlined from '@vicons/material/MoreVertOutlined'
-import store from '@/utils/store';
+import { h, onMounted, reactive } from 'vue';
 import { FormatTime } from '@/utils/tools';
-import { onBeforeRouteLeave, useRouter } from 'vue-router';
-import { Comment, User } from '@/utils/types';
+import { onBeforeRouteLeave } from 'vue-router';
+import { Comment, CommentList as ICommentList, User } from '@/utils/types';
 import RenderLink from './RenderLink.vue';
-import { UploadFileInfo, NIcon } from 'naive-ui';
 import ImageViewer from "@/components/ImageViewer/ImageViewer.vue"
+import CommentList from './CommentList.vue';
+import CommentEdit from './CommentEdit.vue';
 
 
 const props = defineProps(['obj', 'rate'])
-const router = useRouter()
-
-// 发表评论
-const now_comment = reactive<{
-  text: string,
-  anonymous: boolean,
-  loading: boolean,
-  with_image: boolean,
-  rate: number,
-}>(store.last_draft[router.currentRoute.value.fullPath] ?? {
-  text: '',
-  anonymous: false,
-  loading: false,
-  with_image: false,
-  rate: 5,
-})
 
 // 回复评论
 const sub_comment = reactive({
@@ -50,7 +27,7 @@ const sub_comment = reactive({
   reply_obj: '',
 })
 
-const comments = reactive({
+const comments = reactive<ICommentList>({
   order: 'default',
   page: 0,
   end: false,
@@ -58,7 +35,7 @@ const comments = reactive({
   loading: false,
 })
 
-const sub_comments = reactive({
+const sub_comment_list = reactive<ICommentList>({
   modal: false,
   parent: {} as Comment,
   order: 'old',
@@ -68,84 +45,11 @@ const sub_comments = reactive({
   loading: false,
 })
 
-// 上传图片
-const fileList = ref<UploadFileInfo[]>([])
-const upload_url = store.api_url + "/upload/image";
-const upload_head = {
-  'fake-cookie': store.fake_cookie
-}
-
-function UploadHandler({ file, event }: { file: UploadFileInfo, event: ProgressEvent }) {
-  let res = (event.target as XMLHttpRequest);
-  let data = JSON.parse(res.response);
-  file.name = data.mid;
-  window.$message.success("上传成功OvO");
-}
-
-function UploadErrorHandler({ file, event }: { file: UploadFileInfo, event: ProgressEvent }) {
-  let res = JSON.parse((event.target as XMLHttpRequest).response);
-  if (res && res.msg) {
-    window.$message.error(res.msg);
-  }
-}
-
-const image_remove_modal = ref(false);
-let ConfirmRemoveImage: (res: boolean) => void;
-function OnImageRemove() {
-  let promise = new Promise((resolve, reject) => {
-    ConfirmRemoveImage = (res) => {
-      if (res) resolve('');
-      else reject();
-      image_remove_modal.value = false
-    }
-  })
-  image_remove_modal.value = true;
-  return promise;
-}
-
-function Check() {
-  if (now_comment.with_image == false && fileList.value.length == 0 && now_comment.text.length == 0) {
-    window.$message.error('评论不能为空Orz');
-    return false;
-  }
-  if (now_comment.with_image == false) {
-    fileList.value = [];
-  }
-  return true;
-}
-
-function CommentPost(obj: string, parent_list: Comment[], reply_uid = 0, reply_obj = '') {
-  if (!Check()) return;
-  now_comment.loading = true;
-  http.post("/reaction/comments", {
-    obj: obj,
-    text: now_comment.text,
-    anonymous: now_comment.anonymous,
-    reply_uid: reply_uid,
-    reply_obj: reply_obj,
-    rate: props.rate ? Math.round(now_comment.rate * 2) : 0,
-    image_mids: fileList.value.map(i => i.name),
-  }).then(res => {
-    parent_list.unshift(res.data);
-    now_comment.text = "";
-    fileList.value = [];
-    now_comment.anonymous = false;
-    now_comment.loading = false;
-    now_comment.rate = 5;
-    sub_comment.modal = false;
-    sub_comments.modal = false;
-    window.$message.success('评论成功OvO');
-  }).catch(() => {
-    now_comment.loading = false;
-  })
-}
-
 function OpenReplyModal(parent: Comment, reply_user = { 'id': 0 } as User, reply_obj = '') {
   sub_comment.modal = true;
   sub_comment.parent = parent;
   sub_comment.reply_user = reply_user;
   sub_comment.reply_obj = reply_obj;
-  now_comment.rate = 0;
 }
 
 function LoadComments(obj: string, cmts: any) {
@@ -168,307 +72,78 @@ function LoadComments(obj: string, cmts: any) {
 
 
 function OpenSubComments(parent: any) {
-  sub_comments.parent = parent;
-  sub_comments.page = 0;
-  sub_comments.end = false;
-  sub_comments.list = [];
-  sub_comments.modal = true;
-  LoadComments('comment' + parent.id, sub_comments);
+  sub_comment_list.parent = parent;
+  sub_comment_list.page = 0;
+  sub_comment_list.end = false;
+  sub_comment_list.list = [];
+  sub_comment_list.modal = true;
+  LoadComments('comment' + parent.id, sub_comment_list);
 }
-
-
-const like_loading = reactive({} as Map<number, boolean>);
-function Like(i: Comment) {
-  like_loading.set(i.id, true);
-  http.post("/reaction/like", { 'obj': 'comment' + i.id })
-    .then(res => {
-      i.like = res.data.like;
-      i.like_num = res.data.like_num;
-      like_loading.set(i.id, false);
-    }).catch(() => { like_loading.set(i.id, false); })
-}
-
-function Delete(i: any, cmts: any) {
-  http.delete("/reaction/comments/" + i.id)
-    .then(() => {
-      cmts.list = cmts.list.filter((x: any) => (x.id != i.id))
-    })
-}
-
-function renderIcon(icon: any) {
-  return () => h(NIcon, null, { default: () => h(icon) })
-}
-const dropdown = reactive({
-  comment: {} as Comment,
-  options: [
-    {
-      label: '举报',
-      key: 'report',
-      icon: renderIcon(FeedbackOutlined),
-      props: {
-        onClick: () => {
-          router.push('/report/comment' + dropdown.comment.id);
-        }
-      }
-    },
-  ]
-})
-
-watch(now_comment, () => {
-  if (now_comment.text.length) {
-    store.last_draft[router.currentRoute.value.fullPath] = {
-      ...now_comment,
-      timestamp: Date.now()
-    }
-  }
-  else {
-    if (store.last_draft[router.currentRoute.value.fullPath])
-      delete store.last_draft[router.currentRoute.value.fullPath];
-  }
-})
 
 onMounted(() => {
   LoadComments(props.obj, comments);
 })
 
 onBeforeRouteLeave((to, from) => {
-  sub_comments.modal = false;
+  sub_comment_list.modal = false;
 })
 </script>
 
 <template>
-  <n-space vertical>
-    <n-rate v-if="props.rate" v-model:value="now_comment.rate" allow-half size="large" />
-    <n-input v-model:value="now_comment.text" type="textarea" placeholder="沉默不是金" :autosize="{ minRows: 3 }"
-      maxlength="23333" show-count />
-    <n-upload v-show="now_comment.with_image" list-type="image-card" :action="upload_url" :headers="upload_head"
-      @finish="UploadHandler" @error="UploadErrorHandler" :max="1" v-model:file-list="fileList"
-      :on-remove="OnImageRemove" />
-    <n-space justify="space-between">
-      <n-space>
-        <n-button @click="now_comment.with_image = !now_comment.with_image" ghost>附图:{{ now_comment.with_image ? '是'
-          : '否' }}</n-button>
-        <n-button @click="now_comment.anonymous = !now_comment.anonymous" ghost>匿名:{{ now_comment.anonymous ? '是'
-          : '否' }}</n-button>
-      </n-space>
-      <n-button @click="CommentPost(props.obj, comments.list)" type="info" ghost :disabled="now_comment.loading"
-        :loading="now_comment.loading" icon-placement="right">
-        <template #icon>
-          <n-icon>
-            <MessageOutlined />
-          </n-icon>
-        </template>
-        发表评论
-      </n-button>
-    </n-space>
-  </n-space>
-
+  <CommentEdit :target="props.obj" :rate="props.rate" :parent_list="comments.list"
+    @close-reply="() => sub_comment.modal = false" />
 
   <!-- 主评论列表 -->
-  <template v-for="i in comments.list" :key="i.id">
-    <n-divider></n-divider>
-    <div style="display: flex;align-items: top;">
-      <div>
-        <router-link :to="'/user/' + i.user.id">
-          <Avatar :user="i.user" :size="36" round />
-        </router-link>
-      </div>
-      <span style="margin-left: 4px;margin-top:-4px;width:0;flex:1;">
-        <div style="font-size: 16px;">{{ i.user.nickname }}</div>
-        <div style="margin-top: -4px;font-size:14px;">{{ FormatTime(i.create_time) }}</div>
-        <n-rate v-if="props.rate" :value="i.rate / 2" allow-half size="large" readonly />
-        <div style="white-space:pre-wrap;margin-top:4px;word-wrap:break-word;">
-          <RenderLink :value="i.text" />
-        </div>
-        <ImageViewer v-if="i.images.length > 0" :images="i.images" />
-        <n-space :align="'center'">
-          <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading.get(i.id)"
-            :disabled="like_loading.get(i.id)">
-            <template #icon>
-              <n-icon>
-                <ThumbUpFilled v-if="i.like" />
-                <ThumbUpOutlined v-else />
-              </n-icon>
-            </template>
-            {{ i.like_num }}赞同
-          </n-button>
-
-          <n-button @click="OpenReplyModal(i)" text>
-            <template #icon>
-              <n-icon :component="ReplyOutlined" />
-            </template>
-            回复
-          </n-button>
-
-          <n-popconfirm @positive-click="Delete(i, comments)" :show-icon="false" positive-text="确定" negative-text="取消">
-            <template #trigger>
-              <n-button v-show="i.own" text>
-                <template #icon>
-                  <n-icon :component="DeleteOutlined" />
-                </template>
-                删除
-              </n-button>
-            </template>
-            汝真断舍离耶？
-          </n-popconfirm>
-          <n-dropdown :options="dropdown.options" trigger="click">
-            <div style="display:flex;align-items: center;">
-              <n-button @click="dropdown.comment = i" text>
-                <template #icon>
-                  <n-icon :component="MoreVertOutlined" />
-                </template>
-              </n-button>
-            </div>
-          </n-dropdown>
-        </n-space>
-
-        <!-- 子评论预览 -->
-        <div v-if="i.sub.length != 0" style="background-color:#CCCCCC22;padding:4px;border-radius: 4px;">
-          <div v-for="j in i.sub.slice(0, 3)" :key="j.id" style="margin:4px;">
-            {{ j.user.nickname }}：
-            <span v-if="j.reply_user.id != 0">@{{ j.reply_user.nickname + ' ' }}</span>
-            <span style="white-space:pre-wrap;margin-top:4px;word-wrap:break-word;">{{ (j.images.length ? '【图片】' : '') +
-              j.text
-              }}</span>
-          </div>
-          <n-button @click="OpenSubComments(i)" text>共{{ i.comment_num }}条回复>></n-button>
-        </div>
-      </span>
-    </div>
-  </template>
-  <n-divider style="color:var(--text-color-3);font-size:14px;">已加载{{ comments.list.length }}条</n-divider>
+  <CommentList :ctx="comments" :rate="props.rate" @open-reply="OpenReplyModal" @open-sub-comments="OpenSubComments" />
+  <n-divider style="color:var(--text-color-3);font-size:14px;">
+    已加载{{ comments.list.length }}条
+  </n-divider>
   <n-button block @click="LoadComments(props.obj, comments)" :disabled="comments.end" :loading="comments.loading">
-    {{ comments.end ? '木有更多了' : '加载更多' }}</n-button>
+    {{ comments.end ? '木有更多了' : '加载更多' }}
+  </n-button>
 
   <!-- 回复模态框 -->
   <n-modal v-model:show="sub_comment.modal" preset="card" style="width:624px"
     :title="'回复' + (sub_comment.reply_user.id == 0 ? '' : '@' + sub_comment.reply_user.nickname)">
-    <n-space vertical>
-      <n-input v-model:value="now_comment.text" type="textarea" placeholder="沉默不是金" :autosize="{ minRows: 3 }"
-        maxlength="23333" show-count />
-      <n-upload v-show="now_comment.with_image" list-type="image-card" :action="upload_url" :headers="upload_head"
-        @finish="UploadHandler" @error="UploadErrorHandler" :max="1" v-model:file-list="fileList"
-        :on-remove="OnImageRemove" />
-      <n-space justify="space-between">
-        <n-space>
-          <n-button @click="now_comment.with_image = !now_comment.with_image" ghost>附图:{{ now_comment.with_image ? '是'
-            : '否' }}</n-button>
-          <n-button @click="now_comment.anonymous = !now_comment.anonymous" ghost>匿名:{{ now_comment.anonymous ? '是'
-            : '否' }}</n-button>
-        </n-space>
-        <n-button
-          @click="CommentPost('comment' + sub_comment.parent.id, sub_comment.parent.sub, sub_comment.reply_user.id, sub_comment.reply_obj)"
-          type="info" ghost :disabled="now_comment.loading" :loading="now_comment.loading" icon-placement="right">
-          <template #icon>
-            <n-icon>
-              <ReplyOutlined />
-            </n-icon>
-          </template>
-          回复
-        </n-button>
-      </n-space>
-    </n-space>
+    <CommentEdit :subcomment="true" :target="`comment${sub_comment.parent.id}`"
+      :parent_list="sub_comment.parent.sub"
+      :reply_uid="sub_comment.reply_user.id" :reply_obj="sub_comment.reply_obj"
+      @close-reply="() => sub_comment.modal = false"
+      @close-sub-comments="() => sub_comment_list.modal = false" />
   </n-modal>
 
   <!-- 子评论模态框 -->
-  <n-modal v-model:show="sub_comments.modal" preset="card" style="width:624px">
+  <n-modal v-model:show="sub_comment_list.modal" preset="card" style="width:624px">
     <n-scrollbar style="max-height:84vh">
       <div style="display: flex;align-items: top;">
 
         <!-- 子评论的父评论 -->
         <div>
-          <router-link :to="'/user/' + sub_comments.parent.user.id">
-            <Avatar :user="sub_comments.parent.user" :size="36" round />
+          <router-link :to="'/user/' + sub_comment_list.parent!.user.id">
+            <Avatar :user="sub_comment_list.parent!.user" :size="36" round />
           </router-link>
         </div>
+
         <span style="margin-left: 4px;margin-top:-4px">
-          <div style="font-size: 16px;">{{ sub_comments.parent.user.nickname }}</div>
-          <div style="margin-top: -4px;font-size:14px;">{{ FormatTime(sub_comments.parent.create_time) }}</div>
+          <div style="font-size: 16px;">{{ sub_comment_list.parent!.user.nickname }}</div>
+          <div style="margin-top: -4px;font-size:14px;">{{ FormatTime(sub_comment_list.parent!.create_time) }}</div>
           <div style="white-space:pre-wrap;margin-top:4px;word-wrap:break-word;">
-            <RenderLink :value="sub_comments.parent.text" />
+            <RenderLink :value="sub_comment_list.parent!.text" />
           </div>
-          <ImageViewer v-if="sub_comments.parent.images.length > 0" :images="sub_comments.parent.images" />
+          <ImageViewer v-if="sub_comment_list.parent!.images.length > 0" :images="sub_comment_list.parent!.images" />
         </span>
       </div>
 
+      <n-divider style="color:var(--text-color-3);font-size:14px;">
+        现有{{ sub_comment_list.list.length }}条评论
+      </n-divider>
+
       <!-- 子评论列表 -->
-      <template v-for="i in sub_comments.list" :key="i.id">
-        <n-divider style="margin:11px"></n-divider>
-        <div style="display: flex;align-items: top;">
-          <div>
-            <router-link :to="'/user/' + i.user.id">
-              <Avatar :user="i.user" :size="36" round />
-            </router-link>
-          </div>
-          <span style="margin-left: 4px;margin-top:-4px">
-            <div style="font-size: 16px;">{{ i.user.nickname }}</div>
-            <div style="margin-top: -4px;font-size:14px;">{{ FormatTime(i.create_time) }}</div>
-            <div style="white-space: pre-wrap;margin-top:4px;word-wrap:break-word;">
-              <n-a v-if="i.reply_user.id != 0" :href="'/user/' + i.reply_user.id" style="text-decoration:none;">
-                @{{ i.reply_user.nickname + ' ' }}
-              </n-a>
-              <RenderLink :value="i.text" />
-            </div>
-            <ImageViewer v-if="i.images.length > 0" :images="i.images" />
-
-            <n-space :align="'center'">
-              <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading.get(i.id)"
-                :disabled="like_loading.get(i.id)">
-                <template #icon>
-                  <n-icon>
-                    <ThumbUpFilled v-if="i.like" />
-                    <ThumbUpOutlined v-else />
-                  </n-icon>
-                </template>
-                {{ i.like_num }}赞同
-              </n-button>
-
-              <n-button @click="OpenReplyModal(sub_comments.parent, i.user, 'comment' + i.id)" text>
-                <template #icon>
-                  <n-icon>
-                    <ReplyOutlined />
-                  </n-icon>
-                </template>
-                回复
-              </n-button>
-
-              <n-popconfirm @positive-click="Delete(i, sub_comments)" :show-icon="false" positive-text="确定"
-                negative-text="取消">
-                <template #trigger>
-                  <n-button v-show="i.own" text>
-                    <template #icon>
-                      <n-icon>
-                        <DeleteOutlined />
-                      </n-icon>
-                    </template>
-                    删除
-                  </n-button>
-                </template>
-                汝真断舍离耶？
-              </n-popconfirm>
-
-              <n-dropdown :options="dropdown.options" trigger="click">
-                <div style="display:flex;align-items: center;">
-                  <n-button @click="dropdown.comment = i" text>
-                    <template #icon>
-                      <n-icon :component="MoreVertOutlined" />
-                    </template>
-                  </n-button>
-                </div>
-              </n-dropdown>
-            </n-space>
-          </span>
-        </div>
-      </template>
-      <n-divider style="color:var(--text-color-3);font-size:14px;">已加载{{ sub_comments.list.length }}条</n-divider>
-      <n-button block @click="LoadComments('comment' + sub_comments.parent.id, sub_comments)"
-        :disabled="sub_comments.end" :loading="sub_comments.loading">
-        {{ sub_comments.end ? '木有更多了' : '加载更多' }}</n-button>
+      <CommentList :ctx="sub_comment_list" subcomment @open-reply="OpenReplyModal" />
+      <n-divider style="color:var(--text-color-3);font-size:14px;">已加载{{ sub_comment_list.list.length }}条</n-divider>
+      <n-button block @click="LoadComments('comment' + sub_comment_list.parent!.id, sub_comment_list)"
+        :disabled="sub_comment_list.end" :loading="sub_comment_list.loading">
+        {{ sub_comment_list.end ? '木有更多了' : '加载更多' }}</n-button>
     </n-scrollbar>
   </n-modal>
-
-
-  <!-- 删除图片确认 -->
-  <n-modal v-model:show="image_remove_modal" preset="dialog" title="汝真断舍离耶？" positive-text="确认" negative-text="取消"
-    @positive-click="ConfirmRemoveImage(true)" @negative-click="ConfirmRemoveImage(false)" />
 </template>

--- a/src/components/Comment.vue
+++ b/src/components/Comment.vue
@@ -179,13 +179,13 @@ function OpenSubComments(parent: any) {
 
 const like_loading = reactive({} as Map<number, boolean>);
 function Like(i: Comment) {
-  like_loading[i.id] = true;
+  like_loading.set(i.id, true);
   http.post("/reaction/like", { 'obj': 'comment' + i.id })
     .then(res => {
       i.like = res.data.like;
       i.like_num = res.data.like_num;
-      like_loading[i.id] = false;
-    }).catch(() => { like_loading[i.id] = false; })
+      like_loading.set(i.id, false);
+    }).catch(() => { like_loading.set(i.id, false); })
 }
 
 function Delete(i: any, cmts: any) {
@@ -282,7 +282,8 @@ onBeforeRouteLeave((to, from) => {
         </div>
         <ImageViewer v-if="i.images.length > 0" :images="i.images" />
         <n-space :align="'center'">
-          <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading[i.id]" :disabled="like_loading[i.id]">
+          <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading.get(i.id)"
+            :disabled="like_loading.get(i.id)">
             <template #icon>
               <n-icon>
                 <ThumbUpFilled v-if="i.like" />
@@ -328,7 +329,7 @@ onBeforeRouteLeave((to, from) => {
             <span v-if="j.reply_user.id != 0">@{{ j.reply_user.nickname + ' ' }}</span>
             <span style="white-space:pre-wrap;margin-top:4px;word-wrap:break-word;">{{ (j.images.length ? '【图片】' : '') +
               j.text
-            }}</span>
+              }}</span>
           </div>
           <n-button @click="OpenSubComments(i)" text>共{{ i.comment_num }}条回复>></n-button>
         </div>
@@ -411,8 +412,8 @@ onBeforeRouteLeave((to, from) => {
             <ImageViewer v-if="i.images.length > 0" :images="i.images" />
 
             <n-space :align="'center'">
-              <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading[i.id]"
-                :disabled="like_loading[i.id]">
+              <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading.get(i.id)"
+                :disabled="like_loading.get(i.id)">
                 <template #icon>
                   <n-icon>
                     <ThumbUpFilled v-if="i.like" />
@@ -460,8 +461,8 @@ onBeforeRouteLeave((to, from) => {
         </div>
       </template>
       <n-divider style="color:var(--text-color-3);font-size:14px;">已加载{{ sub_comments.list.length }}条</n-divider>
-      <n-button block @click="LoadComments('comment' + sub_comments.parent.id, sub_comments)" :disabled="sub_comments.end"
-        :loading="sub_comments.loading">
+      <n-button block @click="LoadComments('comment' + sub_comments.parent.id, sub_comments)"
+        :disabled="sub_comments.end" :loading="sub_comments.loading">
         {{ sub_comments.end ? '木有更多了' : '加载更多' }}</n-button>
     </n-scrollbar>
   </n-modal>

--- a/src/components/CommentEdit.vue
+++ b/src/components/CommentEdit.vue
@@ -4,7 +4,8 @@
     <n-input v-model:value="now_comment.text" type="textarea" placeholder="沉默不是金" :autosize="{ minRows: 3 }"
       maxlength="23333" show-count />
     <n-upload v-show="now_comment.with_image" list-type="image-card" :action="upload_url" :headers="upload_head"
-      @finish="UploadHandler" @error="UploadErrorHandler" v-model:file-list="fileList" :on-remove="OnImageRemove" />
+      @finish="UploadHandler" @error="UploadErrorHandler" v-model:file-list="fileList"
+      :on-remove="OnImageRemove" :max="1"/>
     <n-space justify="space-between">
       <n-space>
         <n-button @click="now_comment.with_image = !now_comment.with_image" ghost>

--- a/src/components/CommentEdit.vue
+++ b/src/components/CommentEdit.vue
@@ -1,0 +1,218 @@
+<template>
+  <n-space vertical>
+    <n-rate v-if="props.rate && !props.subcomment" v-model:value="now_comment.rate" allow-half size="large" />
+    <n-input v-model:value="now_comment.text" type="textarea" placeholder="沉默不是金" :autosize="{ minRows: 3 }"
+      maxlength="23333" show-count />
+    <n-upload v-show="now_comment.with_image" list-type="image-card" :action="upload_url" :headers="upload_head"
+      @finish="UploadHandler" @error="UploadErrorHandler" v-model:file-list="fileList" :on-remove="OnImageRemove" />
+    <n-space justify="space-between">
+      <n-space>
+        <n-button @click="now_comment.with_image = !now_comment.with_image" ghost>
+          附图:{{ now_comment.with_image ? '是' : '否' }}
+        </n-button>
+        <n-button @click="now_comment.anonymous = !now_comment.anonymous" ghost>
+          匿名:{{ now_comment.anonymous ? '是' : '否' }}
+        </n-button>
+      </n-space>
+      <n-space>
+        <n-popconfirm v-if="hasDraft" @positive-click="DiscardDraft" positive-text="确定" negative-text="取消">
+          <template #trigger>
+            <n-button type="error" ghost>放弃草稿</n-button>
+          </template>
+          汝真放弃耶？放弃的草稿无法恢复。
+        </n-popconfirm>
+        <n-button @click="CommentPost(
+          props.target,
+          props.parent_list,
+          props.reply_uid,
+          props.reply_obj
+        )" type="info" ghost :disabled="now_comment.loading" :loading="now_comment.loading" icon-placement="right">
+          <template #icon>
+            <n-icon>
+              <MessageOutlined v-if="!props.subcomment" />
+              <ReplyOutlined v-else />
+            </n-icon>
+          </template>
+          {{ props.subcomment ? "回复" : "发表评论" }}
+        </n-button>
+      </n-space>
+    </n-space>
+  </n-space>
+
+  <!-- 删除图片确认 -->
+  <n-modal v-model:show="image_remove_modal" preset="dialog" title="汝真断舍离耶？" positive-text="确认" negative-text="取消"
+    @positive-click="ConfirmRemoveImage(true)" @negative-click="ConfirmRemoveImage(false)" />
+</template>
+
+<script lang="ts" setup>
+import http from '@/utils/request';
+import store from '@/utils/store';
+import { Comment } from '@/utils/types';
+import { UploadFileInfo } from 'naive-ui';
+import { onMounted, reactive, ref, watch } from 'vue';
+import { useRouter } from 'vue-router';
+
+import MessageOutlined from '@vicons/material/MessageOutlined';
+import ReplyOutlined from '@vicons/material/ReplyOutlined';
+import { FormatTime } from '@/utils/tools';
+import { computed } from 'vue';
+
+const router = useRouter();
+
+const props = defineProps({
+  subcomment: {
+    type: Boolean,
+    default: false
+  },
+  rate: {
+    type: Boolean,
+    default: false
+  },
+  target: {
+    type: String,
+    required: true
+  },
+  parent_list: {
+    type: Array<Comment>,
+    required: true
+  },
+  reply_uid: {
+    type: Number,
+    default: 0
+  },
+  reply_obj: {
+    type: String,
+    default: ''
+  }
+})
+
+const emits = defineEmits<{
+  closeReply: [],
+  closeSubComments: [],
+}>()
+
+// 发表评论
+const now_comment = reactive<{
+  text: string,
+  anonymous: boolean,
+  loading: boolean,
+  with_image: boolean,
+  rate: number,
+}>(store.last_draft[router.currentRoute.value.fullPath] ?? {
+  text: '',
+  anonymous: false,
+  loading: false,
+  with_image: false,
+  rate: 5,
+})
+
+// 上传图片
+const fileList = ref<UploadFileInfo[]>([])
+const upload_url = store.api_url + "/upload/image";
+const upload_head = {
+  'fake-cookie': store.fake_cookie
+}
+
+const Check = () => {
+  if (now_comment.with_image == false && fileList.value.length == 0 && now_comment.text.length == 0) {
+    window.$message.error('评论不能为空Orz');
+    return false;
+  }
+  if (now_comment.with_image == false) {
+    fileList.value = [];
+  }
+  return true;
+}
+
+const CommentPost = (obj: string, parent_list: Comment[], reply_uid = 0, reply_obj = '') => {
+  if (!Check()) return;
+  now_comment.loading = true;
+  http.post("/reaction/comments", {
+    obj: obj,
+    text: now_comment.text,
+    anonymous: now_comment.anonymous,
+    reply_uid: reply_uid,
+    reply_obj: reply_obj,
+    rate: props.rate ? Math.round(now_comment.rate * 2) : 0,
+    image_mids: fileList.value.map(i => i.name),
+  }).then(res => {
+    parent_list.unshift(res.data);
+    now_comment.text = "";
+    fileList.value = [];
+    now_comment.anonymous = false;
+    now_comment.with_image = false;
+    now_comment.loading = false;
+    now_comment.rate = 5;
+    emits("closeReply");
+    emits("closeSubComments");
+    window.$message.success('评论成功OvO');
+  }).catch(() => {
+    now_comment.loading = false;
+  })
+}
+
+const UploadHandler = ({ file, event }: { file: UploadFileInfo, event: ProgressEvent }) => {
+  let res = (event.target as XMLHttpRequest);
+  let data = JSON.parse(res.response);
+  file.name = data.mid;
+  window.$message.success("上传成功OvO");
+}
+
+const UploadErrorHandler = ({ file, event }: { file: UploadFileInfo, event: ProgressEvent }) => {
+  let res = JSON.parse((event.target as XMLHttpRequest).response);
+  if (res && res.msg) {
+    window.$message.error(res.msg);
+  }
+}
+
+const image_remove_modal = ref(false);
+let ConfirmRemoveImage: (res: boolean) => void;
+const OnImageRemove = () => {
+  let promise = new Promise((resolve, reject) => {
+    ConfirmRemoveImage = (res) => {
+      if (res) resolve('');
+      else reject();
+      image_remove_modal.value = false
+    }
+  })
+  image_remove_modal.value = true;
+  return promise;
+}
+
+watch(now_comment, () => {
+  if (now_comment.text.length) {
+    store.last_draft[props.target] = {
+      ...now_comment,
+      timestamp: Date.now()
+    }
+  }
+  else {
+    DiscardDraft();
+  }
+})
+
+const DiscardDraft = () => {
+  now_comment.text = "";
+  if (store.last_draft[props.target])
+    delete store.last_draft[props.target];
+
+  hasDraft.value = false;
+}
+
+const draftComment = computed(() => {
+  return store.last_draft[props.target]
+})
+
+const hasDraft = ref(!!draftComment.value);
+
+onMounted(() => {
+  if (hasDraft.value) {
+    now_comment.text = draftComment.value.text;
+    now_comment.anonymous = draftComment.value.anonymous;
+    now_comment.with_image = draftComment.value.with_image;
+    now_comment.rate = draftComment.value.rate;
+
+    window.$message.success(`已恢复 ${FormatTime(draftComment.value.timestamp / 1000)} 的草稿 OvO`);
+  }
+})
+</script>

--- a/src/components/CommentList.vue
+++ b/src/components/CommentList.vue
@@ -1,0 +1,161 @@
+<template>
+  <template v-for="i in props.ctx.list" :key="i.id">
+    <n-divider :style="`margin:${subcomment ? 11 : 24}px`"></n-divider>
+    <div style="display: flex;align-items: top;">
+      <div>
+        <router-link :to="'/user/' + i.user.id">
+          <Avatar :user="i.user" :size="36" round />
+        </router-link>
+      </div>
+      <span style="margin-left: 4px;margin-top:-4px;flex:1">
+        <div style="font-size: 16px;">{{ i.user.nickname }}</div>
+        <div style="margin-top: -4px;font-size:14px;">{{ FormatTime(i.create_time) }}</div>
+        <n-rate v-if="props.rate && !props.subcomment" :value="i.rate / 2" allow-half size="large" readonly />
+        <div style="white-space: pre-wrap;margin-top:4px;word-wrap:break-word;">
+          <n-a v-if="i.reply_user.id != 0" :href="'/user/' + i.reply_user.id" style="text-decoration:none;">
+            @{{ i.reply_user.nickname + ' ' }}
+          </n-a>
+          <RenderLink :value="i.text" />
+        </div>
+        <ImageViewer v-if="i.images.length > 0" :images="i.images" />
+
+        <n-space :align="'center'">
+          <n-button @click="Like(i)" color="#fb7299" text :loading="like_loading.get(i.id)"
+            :disabled="like_loading.get(i.id)">
+            <template #icon>
+              <n-icon>
+                <ThumbUpFilled v-if="i.like" />
+                <ThumbUpOutlined v-else />
+              </n-icon>
+            </template>
+            {{ i.like_num }}赞同
+          </n-button>
+
+          <n-button text @click="() => (props.ctx.parent)
+              ? OpenReplyModal(props.ctx.parent, i.user, 'comment' + i.id)
+              : OpenReplyModal(i)">
+            <template #icon>
+              <n-icon>
+                <ReplyOutlined />
+              </n-icon>
+            </template>
+            回复
+          </n-button>
+
+          <n-popconfirm @positive-click="Delete(i, props.ctx)" :show-icon="false" positive-text="确定"
+            negative-text="取消">
+            <template #trigger>
+              <n-button v-show="i.own" text>
+                <template #icon>
+                  <n-icon>
+                    <DeleteOutlined />
+                  </n-icon>
+                </template>
+                删除
+              </n-button>
+            </template>
+            汝真断舍离耶？
+          </n-popconfirm>
+
+          <n-dropdown :options="dropdown.options" trigger="click">
+            <div style="display:flex;align-items: center;">
+              <n-button @click="dropdown.comment = i" text>
+                <template #icon>
+                  <n-icon :component="MoreVertOutlined" />
+                </template>
+              </n-button>
+            </div>
+          </n-dropdown>
+        </n-space>
+
+        <!-- 子评论预览 -->
+        <div v-if="i.sub.length != 0" style="background-color:#CCCCCC22;padding:4px;border-radius: 4px;">
+          <div v-for="j in i.sub.slice(0, 3)" :key="j.id" style="margin:4px;">
+            {{ j.user.nickname }}：
+            <span v-if="j.reply_user.id != 0">@{{ j.reply_user.nickname + ' ' }}</span>
+            <span style="white-space:pre-wrap;margin-top:4px;word-wrap:break-word;">{{ (j.images.length ? '【图片】' : '') +
+              j.text
+              }}</span>
+          </div>
+          <n-button @click="OpenSubComments(i)" text>共{{ i.comment_num }}条回复>></n-button>
+        </div>
+      </span>
+    </div>
+  </template>
+</template>
+
+<script setup lang="tsx">
+import { FormatTime } from '@/utils/tools';
+import { PropType, reactive, ref } from 'vue';
+import http from '@/utils/request';
+import { Comment, CommentList, User } from '@/utils/types';
+import { NIcon } from 'naive-ui';
+import { h } from 'vue';
+import { useRouter } from 'vue-router';
+
+import MoreVertOutlined from '@vicons/material/MoreVertOutlined';
+import FeedbackOutlined from '@vicons/material/FeedbackOutlined';
+import ThumbUpOutlined from '@vicons/material/ThumbUpOutlined'
+import ThumbUpFilled from '@vicons/material/ThumbUpFilled'
+import DeleteOutlined from '@vicons/material/DeleteOutlined'
+import ReplyOutlined from '@vicons/material/ReplyOutlined'
+
+const router = useRouter();
+
+const props = defineProps({
+  ctx: { type: Object as PropType<CommentList>, required: true },
+  rate: { type: Boolean, default: false },
+  subcomment: { type: Boolean, default: false },
+})
+
+const emits = defineEmits<{
+  openReply: [parent: Comment, reply_user: User, reply_obj: string],
+  openSubComments: [comm: Comment],
+}>()
+
+const like_loading = ref<Map<number, boolean>>(new Map());
+const Like = (comm: Comment) => {
+  like_loading.value.set(comm.id, true);
+  http.post("/reaction/like", { 'obj': 'comment' + comm.id })
+    .then(res => {
+      comm.like = res.data.like;
+      comm.like_num = res.data.like_num;
+      like_loading.value.set(comm.id, false);
+    }).catch(() => { like_loading.value.set(comm.id, false); })
+}
+
+const Delete = (i: any, cmts: any) => {
+  http.delete("/reaction/comments/" + i.id)
+    .then(() => {
+      cmts.list = cmts.list.filter((x: any) => (x.id != i.id))
+    })
+}
+
+const renderIcon = (icon: any) => {
+  return () => h(NIcon, null, { default: () => h(icon) })
+}
+
+const dropdown = reactive({
+  comment: {} as Comment,
+  options: [
+    {
+      label: '举报',
+      key: 'report',
+      icon: renderIcon(FeedbackOutlined),
+      props: {
+        onClick: () => {
+          router.push('/report/comment' + dropdown.comment.id);
+        }
+      }
+    },
+  ]
+})
+
+const OpenReplyModal = (parent: Comment, reply_user = { 'id': 0 } as User, reply_obj = '') => {
+  emits("openReply", parent, reply_user, reply_obj);
+}
+
+const OpenSubComments = (comm: Comment) => {
+  emits("openSubComments", comm);
+}
+</script>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -79,3 +79,12 @@ export interface Comment {
     sub: Comment[]; // 子评论
 }
 
+export interface CommentList {
+    order: 'default' | 'old',
+    page: number,
+    end: boolean,
+    list: Comment[],
+    loading: boolean,
+    parent?: Comment,
+    modal?: boolean
+}


### PR DESCRIPTION
- 重构了评论相关代码, 原有 `Comments.vue` 代码过于耦合, 存在复制粘贴的重复部分; 现拆分为编辑相关的 `CommentEdit.vue` 和显示相关的 `CommentList.vue`. 
- 通过拆分为组件, 每个评论编辑界面都有自己的数据绑定, 解决了 #48 .

# Questions

- 拆分后 `Comments.vue` 中并没有多少实际业务代码, 更偏向于布局描述, 是否应该移动到 `views` 中? 但是考虑到 `GalleryShow.vue` 又直接依赖于其, 作为 `component` 也不是不能接受 (?)
- 图片上传组件原先限制为仅一张图片, 能否改为多张图片上传?

# TODOs

- 希望进行更多测试, 确保重构后的组件没有行为差异. 