### PR TITLE
⚠️ 添加可编辑的服务可用性提示

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2

--- a/components.d.ts
+++ b/components.d.ts
@@ -58,7 +58,6 @@ declare module 'vue' {
     NLayoutContent: typeof import('naive-ui')['NLayoutContent']
     NLayoutFooter: typeof import('naive-ui')['NLayoutFooter']
     NLayoutHeader: typeof import('naive-ui')['NLayoutHeader']
-    NLink: typeof import('naive-ui')['NLink']
     NMenu: typeof import('naive-ui')['NMenu']
     NMessageProvider: typeof import('naive-ui')['NMessageProvider']
     NModal: typeof import('naive-ui')['NModal']

--- a/components.d.ts
+++ b/components.d.ts
@@ -58,6 +58,7 @@ declare module 'vue' {
     NLayoutContent: typeof import('naive-ui')['NLayoutContent']
     NLayoutFooter: typeof import('naive-ui')['NLayoutFooter']
     NLayoutHeader: typeof import('naive-ui')['NLayoutHeader']
+    NLink: typeof import('naive-ui')['NLink']
     NMenu: typeof import('naive-ui')['NMenu']
     NMessageProvider: typeof import('naive-ui')['NMessageProvider']
     NModal: typeof import('naive-ui')['NModal']

--- a/components.d.ts
+++ b/components.d.ts
@@ -85,6 +85,7 @@ declare module 'vue' {
     RenderLink: typeof import('./src/components/RenderLink.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
+    ServiceStatusAlert: typeof import('./src/components/ServiceStatusAlert.vue')['default']
     Subscription: typeof import('./src/components/Subscription.vue')['default']
   }
 }

--- a/src/components/ServiceStatusAlert.vue
+++ b/src/components/ServiceStatusAlert.vue
@@ -1,0 +1,37 @@
+<template>
+  <n-alert :type="status?.type" title="Oops..." v-if="status">
+    {{ status?.message }}
+  </n-alert>
+</template>
+
+<script setup lang="ts">
+import http from "@/utils/request";
+import { ServiceKey, UPDATE_INTERVAL, type ServiceStatusResponse } from "@/utils/serviceStatus";
+import store from "@/utils/store";
+import { computed, onMounted, ref } from "vue";
+
+const props = defineProps<{
+  service: ServiceKey;
+}>();
+
+const status = computed(() => store.service_status.items[props.service])
+
+onMounted(async () => {
+  if (Date.now() - store.service_status.lastUpdated > UPDATE_INTERVAL) {
+    const resp = await http.get<{ data: ServiceStatusResponse }>("/variables?obj=service_status")
+    store.service_status = resp.data.data
+    // const resp: ServiceStatusResponse = {
+    //   lastUpdated: Date.now(),
+    //   items: {
+    //     [ServiceKey.Score]: {
+    //       type: "error",
+    //       message: "由于统一认证服务变动，暂时无法使用"
+    //     }
+    //   }
+    // }
+    // store.service_status = resp
+  }
+
+  console.debug("[ServiceStatusAlert]", store.service_status.items, props.service, status.value)
+})
+</script>

--- a/src/components/ServiceStatusAlert.vue
+++ b/src/components/ServiceStatusAlert.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import http from "@/utils/request";
-import { ServiceKey, UPDATE_INTERVAL, type ServiceStatusResponse } from "@/utils/serviceStatus";
+import { ServiceKey, ServiceStatusItems, UPDATE_INTERVAL, type ServiceStatusResponse } from "@/utils/serviceStatus";
 import store from "@/utils/store";
 import { computed, onMounted, ref } from "vue";
 
@@ -18,18 +18,14 @@ const status = computed(() => store.service_status.items[props.service])
 
 onMounted(async () => {
   if (Date.now() - store.service_status.lastUpdated > UPDATE_INTERVAL) {
-    const resp = await http.get<{ data: ServiceStatusResponse }>("/variables?obj=service_status")
-    store.service_status = resp.data.data
-    // const resp: ServiceStatusResponse = {
-    //   lastUpdated: Date.now(),
-    //   items: {
-    //     [ServiceKey.Score]: {
-    //       type: "error",
-    //       message: "由于统一认证服务变动，暂时无法使用"
-    //     }
-    //   }
-    // }
-    // store.service_status = resp
+    const resp = await http.get("/variables?obj=service_status")
+    const result: ServiceStatusItems | null = JSON.parse(resp.data.data)
+    if (result) {
+      store.service_status = {
+        lastUpdated: Date.now(),
+        items: result,
+      }
+    }
   }
 
   console.debug("[ServiceStatusAlert]", store.service_status.items, props.service, status.value)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -135,6 +135,11 @@ const router = createRouter({
       component: () => import('@/views/admin/Billboard.vue')
     },
     {
+      path: '/admin/service-status/',
+      name: 'admin_service_status',
+      component: () => import('@/views/admin/ServiceStatus.vue')
+    },
+    {
       path: '/:pathMatch(.*)',
       name: '404',
       component: () => import('@/views/404.vue')

--- a/src/utils/serviceStatus.ts
+++ b/src/utils/serviceStatus.ts
@@ -1,0 +1,34 @@
+enum ServiceKey {
+  Score = "score",
+  Schedule = "schedule",
+}
+
+// 10分钟轮询间隔
+const UPDATE_INTERVAL = 10 * 60 * 1000;
+
+interface ServiceStatusResponse {
+  lastUpdated: number;
+  items: ServiceStatusItems;
+}
+
+const EMPTY_SERVICE_STATUS: ServiceStatusResponse = {
+  lastUpdated: 0,
+  items: {}
+}
+
+type ServiceStatusItems = {
+  [key in ServiceKey]?: ServiceStatusData;
+};
+
+interface ServiceStatusData {
+  type: "info" | "warning" | "error";
+  message: string;
+}
+
+export type {
+  ServiceStatusResponse,
+  ServiceStatusItems,
+  ServiceStatusData,
+}
+
+export { ServiceKey, UPDATE_INTERVAL, EMPTY_SERVICE_STATUS };

--- a/src/utils/store.ts
+++ b/src/utils/store.ts
@@ -7,6 +7,7 @@
  */
 import { reactive, watch } from "vue";
 import package_json from "../../package.json";
+import { EMPTY_SERVICE_STATUS, ServiceStatusResponse } from "./serviceStatus";
 
 let s = window.localStorage.getItem("store");
 let x: any = {};
@@ -26,6 +27,7 @@ const store = reactive({
   grade_query: x.grade_query || {},
   last_draft: x.last_draft ?? {},
   hide_bot: x.hide_bot ?? false,
+  service_status: x.service_status as ServiceStatusResponse ?? EMPTY_SERVICE_STATUS,
 });
 
 watch(store, () => {

--- a/src/views/Schedule.vue
+++ b/src/views/Schedule.vue
@@ -11,6 +11,8 @@ import { bitLoginRequest, bitLoginState } from "@/utils/bit-login";
 import { OpenLink } from "@/utils/tools";
 import { reactive } from "vue";
 import BitLoginSetting from "@/components/BitLoginSetting.vue";
+import { ServiceKey } from "@/utils/serviceStatus";
+import ServiceStatusAlert from "@/components/ServiceStatusAlert.vue"
 
 const user = reactive({
   sid: "",
@@ -50,6 +52,7 @@ function GetSchedule(username, password) {
         <BitLoginSetting />
       </template>
       <n-space vertical v-if="!schedule.url">
+        <ServiceStatusAlert :service="ServiceKey.Schedule" />
         <n-input v-model:value="user.sid" type="number" placeholder="学号" />
         <n-input
           v-model:value="user.password"

--- a/src/views/Score.vue
+++ b/src/views/Score.vue
@@ -2,7 +2,7 @@
  * @Author: flwfdd
  * @Date: 2022-06-26 18:52:08
  * @LastEditTime: 2024-02-26 17:20:06
- * @Description: 
+ * @Description:
  * _(:з」∠)_
 -->
 <script setup lang="ts">
@@ -13,6 +13,8 @@ import BitLoginSetting from "@/components/BitLoginSetting.vue";
 import { DataTableRowKey } from "naive-ui";
 import { RowData } from "naive-ui/es/data-table/src/interface";
 import { reactive, ref, onMounted, watch } from "vue";
+import ServiceStatusAlert from "@/components/ServiceStatusAlert.vue";
+import { ServiceKey } from "@/utils/serviceStatus";
 
 const user = reactive({
   sid: store.grade_query.sid,
@@ -332,6 +334,8 @@ function GetReport(username, password) {
 
 <template>
   <n-space vertical>
+    <ServiceStatusAlert :service="ServiceKey.Score" />
+
     <n-card title="成寄查询">
       <template #header-extra>
         <BitLoginSetting />

--- a/src/views/Score.vue
+++ b/src/views/Score.vue
@@ -333,7 +333,7 @@ function GetReport(username, password) {
 </script>
 
 <template>
-  <n-space vertical>
+  <n-space vertical class="container">
     <ServiceStatusAlert :service="ServiceKey.Score" />
 
     <n-card title="成寄查询">

--- a/src/views/admin/ServiceStatus.vue
+++ b/src/views/admin/ServiceStatus.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import SaveFilled from "@vicons/material/SaveFilled";
+import http from "@/utils/request";
+import {
+  ServiceKey,
+  type ServiceStatusData,
+  type ServiceStatusItems,
+} from "@/utils/serviceStatus";
+import type { FormInst, FormRules } from "naive-ui";
+import { onMounted, reactive, ref } from "vue";
+
+const services = Object.values(ServiceKey) as ServiceKey[];
+
+const typeOptions = [
+  { label: "提示", value: "info" },
+  { label: "警告", value: "warning" },
+  { label: "错误", value: "error" },
+];
+
+const statusItems = reactive<ServiceStatusItems>({});
+const formRef = ref<FormInst | null>(null);
+const loading = ref(false);
+const submitting = ref(false);
+const rules: FormRules = Object.fromEntries(
+  services.map((key) => [
+    `${key}.message`,
+    {
+      required: true,
+      message: "请输入通知内容",
+      trigger: ["input", "blur"],
+    },
+  ])
+);
+
+function setEnabled(key: ServiceKey, enabled: boolean) {
+  if (enabled) {
+    statusItems[key] ??= { type: "info", message: "" };
+  } else {
+    delete statusItems[key];
+  }
+}
+
+function setType(key: ServiceKey, type: ServiceStatusData["type"]) {
+  const item = statusItems[key];
+  if (item) item.type = type;
+}
+
+function setMessage(key: ServiceKey, message: string) {
+  const item = statusItems[key];
+  if (item) item.message = message;
+}
+
+async function load() {
+  loading.value = true;
+  try {
+    const res = await http.get("/variables?obj=service_status");
+    const items = JSON.parse(res.data.data) as ServiceStatusItems;
+
+    Object.keys(statusItems).forEach((key) => {
+      delete statusItems[key as ServiceKey];
+    });
+    Object.assign(statusItems, items);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function submit() {
+  await formRef.value?.validate();
+  submitting.value = true;
+  try {
+    await http.post("/variables", {
+      obj: "service_status",
+      data: JSON.stringify(statusItems),
+    });
+  } finally {
+    submitting.value = false;
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="container">
+    <n-space vertical>
+      <h2>服务状态通知</h2>
+
+      <n-spin :show="loading">
+        <n-form ref="formRef" :model="statusItems" :rules="rules" label-placement="left" label-width="90">
+          <n-space vertical>
+            <n-card v-for="service in services" :key="service" :title="service">
+              <n-form-item label="显示通知">
+                <n-switch
+                  :value="Boolean(statusItems[service])"
+                  @update:value="setEnabled(service, $event)" />
+              </n-form-item>
+
+              <n-collapse-transition :show="statusItems[service] !== undefined">
+                <n-form-item label="通知等级" :path="`${service}.type`">
+                  <n-select
+                    :value="statusItems[service]?.type"
+                    :options="typeOptions"
+                    @update:value="setType(service, $event as ServiceStatusData['type'])"
+                  />
+                </n-form-item>
+                <n-form-item label="通知内容" :path="`${service}.message`">
+                  <n-input
+                    :value="statusItems[service]?.message"
+                    type="textarea"
+                    placeholder="请输入通知内容"
+                    @update:value="setMessage(service, $event)"
+                  />
+                </n-form-item>
+              </n-collapse-transition>
+            </n-card>
+          </n-space>
+        </n-form>
+      </n-spin>
+
+      <n-button :loading="submitting" :disabled="loading" @click="submit" style="width: 100%">
+        <template #icon>
+          <SaveFilled />
+        </template>
+        保存
+      </n-button>
+    </n-space>
+  </div>
+</template>

--- a/src/views/admin/ServiceStatus.vue
+++ b/src/views/admin/ServiceStatus.vue
@@ -73,7 +73,12 @@ async function submit() {
       obj: "service_status",
       data: JSON.stringify(statusItems),
     });
-  } finally {
+  } catch (err: any) {
+    if (err.request && err.request.status >= 400) {
+      if (err.response.data.msg) window.$message.error(err.response.data.msg);
+      else window.$message.error("出错了Orz");
+    }
+  }finally {
     submitting.value = false;
   }
 }


### PR DESCRIPTION
**合并后需要有管理权限的用户在后台提交一次全部禁用，来添加variable避免报错**

在成绩查询和课表导出页面添加了可后台启用的服务可用性提示

<img width="1324" height="1756" alt="图片" src="https://github.com/user-attachments/assets/b2983768-3b92-4afa-9b5d-1d8edd64f277" />

管理可在 /admin/service-status/ 中启用和编辑服务可用性提示

<img width="1324" height="1756" alt="8f53ab95dca5c8c828e64d0d081b1e19" src="https://github.com/user-attachments/assets/653e9a1f-c3fb-46cf-8844-75d52d4ab8fb" />
